### PR TITLE
stop propagation on touch screens

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -15,6 +15,11 @@ function onClickDropdown() {
         ev.stopPropagation()
     })
     
+    document.getElementById('myDropdown').addEventListener('touchstart', (ev) => {
+        ev.stopImmediatePropagation()
+        ev.stopPropagation()
+    })
+    
     //Toggle
     document.getElementById("myDropdown").classList.toggle("show");
 }


### PR DESCRIPTION
If you go in inspect mode and view with a touch screen, then you would still get the error where the popup opens when click PNG or JPEG under export. This should fix it.